### PR TITLE
feat: implicit defensive route caching (v3.2.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,33 @@ registered, and `RouteNotRenderableException` when the named route's
 `IRoute` implementation does not also implement `IRenderableRoute`
 (the built-in `TokenizedRoute` and `StringRoute` both do).
 
+### Route Caching
+
+Route patterns are parsed once and cached to a PHP file so that subsequent
+requests skip the parsing cost. Caching is on by default and uses a path
+under the system temp directory derived from the current working
+directory.
+
+```php
+// Default — caching enabled at sys_get_temp_dir() . '/ccglabs-router-...'
+$app = new Application();
+
+// Explicit cache file path
+$app = new Application(cacheFile: __DIR__ . '/cache/routes.php');
+
+// Disable caching
+$app = new Application(cacheFile: false);
+```
+
+Only the parsed route token lists are cached — handlers stay in your
+code and run on every request as usual. Cache failures (unwritable
+path, corrupt cache file) are silently swallowed: the application
+continues to work without caching rather than throwing.
+
+The cache invalidates itself when registered routes change. If a route
+is removed from your code, its entry is pruned from the cache on the
+next request that registers a different set of routes.
+
 ## Migrating from 2.x
 
 Version 3.0 changes how route parameters reach handlers. The previous

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "ccglabs/router",
     "description": "A simple router for simple applications.",
     "type": "library",
-    "version": "3.1.0",
+    "version": "3.2.0",
     "license": "MIT",
     "autoload": {
         "psr-4": {

--- a/src/Application.php
+++ b/src/Application.php
@@ -195,13 +195,6 @@ class Application implements RequestHandlerInterface
         return $this;
     }
 
-    /**
-     * Builds a TokenizedRoute for the given path string, using the cache
-     * if a previous run parsed the same path. Records the result so the
-     * cache stays up to date. The cache itself handles the disabled case:
-     * getCached() returns null on a disabled cache, and record() is a
-     * harmless no-op.
-     */
     private function resolveTokenizedRoute(string $path): TokenizedRoute
     {
         $cached = $this->cache->getCached($path);

--- a/src/Application.php
+++ b/src/Application.php
@@ -26,6 +26,12 @@ use Psr\Http\Server\RequestHandlerInterface;
  *
  * Routes registered with a $name argument can be referenced by that name
  * via Application::urlFor() to build URL paths from parameter values.
+ *
+ * String routes registered via addRoute() (or the get/post/etc. helpers) are
+ * cached: their parsed token list is persisted to a PHP file so the parsing
+ * cost is skipped on subsequent requests. Caching is implicit and defensive
+ * — failures to read or write the cache never throw. Pass `cacheFile: false`
+ * to disable caching entirely.
  */
 class Application implements RequestHandlerInterface
 {
@@ -46,9 +52,16 @@ class Application implements RequestHandlerInterface
      */
     protected array $namedRoutes = [];
 
+    private RouteCache $cache;
+
     public function __construct(
-        private IHandlerLocator $handlerLocator = new DefaultHandlerLocator()
+        private IHandlerLocator $handlerLocator = new DefaultHandlerLocator(),
+        string|false|null $cacheFile = null,
     ) {
+        if ($cacheFile === null) {
+            $cacheFile = RouteCache::defaultPath();
+        }
+        $this->cache = new RouteCache($cacheFile);
     }
 
     public function getHandlerLocator(): IHandlerLocator
@@ -58,6 +71,8 @@ class Application implements RequestHandlerInterface
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
+        $this->cache->persist();
+
         $match = $this->getHandlerLocator()->locate($request);
         $request = $request->withAttribute(self::ROUTE_PARAMS_ATTRIBUTE, $match->params);
 
@@ -163,7 +178,7 @@ class Application implements RequestHandlerInterface
         ?string $name = null,
     ): self {
         if (is_string($route)) {
-            $route = TokenizedRoute::fromPath($route);
+            $route = $this->resolveTokenizedRoute($route);
         }
 
         if ($name !== null) {
@@ -178,5 +193,28 @@ class Application implements RequestHandlerInterface
     {
         $this->middlewares[] = $middleware;
         return $this;
+    }
+
+    /**
+     * Builds a TokenizedRoute for the given path string, using the cache
+     * if a previous run parsed the same path. Records the result so the
+     * cache stays up to date.
+     */
+    private function resolveTokenizedRoute(string $path): TokenizedRoute
+    {
+        if ($this->cache->isEnabled()) {
+            $cached = $this->cache->getCached($path);
+            if ($cached !== null) {
+                return new TokenizedRoute($cached);
+            }
+        }
+
+        $route = TokenizedRoute::fromPath($path);
+
+        if ($this->cache->isEnabled()) {
+            $this->cache->record($path, $route->getTokens());
+        }
+
+        return $route;
     }
 }

--- a/src/Application.php
+++ b/src/Application.php
@@ -198,22 +198,19 @@ class Application implements RequestHandlerInterface
     /**
      * Builds a TokenizedRoute for the given path string, using the cache
      * if a previous run parsed the same path. Records the result so the
-     * cache stays up to date.
+     * cache stays up to date. The cache itself handles the disabled case:
+     * getCached() returns null on a disabled cache, and record() is a
+     * harmless no-op.
      */
     private function resolveTokenizedRoute(string $path): TokenizedRoute
     {
-        if ($this->cache->isEnabled()) {
-            $cached = $this->cache->getCached($path);
-            if ($cached !== null) {
-                return new TokenizedRoute($cached);
-            }
+        $cached = $this->cache->getCached($path);
+        if ($cached !== null) {
+            return new TokenizedRoute($cached);
         }
 
         $route = TokenizedRoute::fromPath($path);
-
-        if ($this->cache->isEnabled()) {
-            $this->cache->record($path, $route->getTokens());
-        }
+        $this->cache->record($path, $route->getTokens());
 
         return $route;
     }

--- a/src/RouteCache.php
+++ b/src/RouteCache.php
@@ -22,51 +22,33 @@ use Throwable;
  */
 class RouteCache
 {
-    /**
-     * Path-prefix used by defaultPath() under sys_get_temp_dir().
-     */
-    public const DEFAULT_PATH_PREFIX = 'ccglabs-router-';
+    private const DEFAULT_PATH_PREFIX = 'ccglabs-router-';
 
     /**
-     * Returns the default cache file path: a PHP file in the system
-     * temp directory whose name is derived from the current working
-     * directory so that different projects on the same host get
-     * different default cache files.
+     * Default cache file path: derived from cwd so different projects on the
+     * same host don't collide on a shared temp file.
      */
     public static function defaultPath(): string
     {
+        // Fall back to __FILE__ if getcwd() fails (e.g. cwd was deleted under us)
+        // so the hash still resolves to a stable, project-specific value.
         $cwd = getcwd() ?: __FILE__;
         $hash = substr(md5($cwd), 0, 16);
         return sys_get_temp_dir() . DIRECTORY_SEPARATOR . self::DEFAULT_PATH_PREFIX . $hash . '.php';
     }
 
-    /**
-     * Path-string to token-list map. Loaded from the cache file at
-     * construction; mutated by record() during route registration;
-     * trimmed and rewritten by persist().
-     *
-     * @var array<string, string[]>
-     */
+    /** @var array<string, string[]> */
     private array $tokens = [];
 
-    /**
-     * Set of path-strings recorded or hit during this run. Used by
-     * persist() to prune entries no longer in the route table.
-     *
-     * @var array<string, true>
-     */
+    /** @var array<string, true> */
     private array $touched = [];
 
-    /**
-     * Whether persist() needs to write the cache file.
-     */
     private bool $dirty = false;
 
     /**
-     * Whether persist() has already done its work successfully this run.
-     * Used to short-circuit on the request hot path: persist() is called
-     * from Application::handle() on every request, but the cache shape
-     * cannot change during dispatch, so we only need to act once.
+     * Short-circuits persist() on the request hot path. persist() is called
+     * from Application::handle() on every request, but the cache shape can't
+     * change during dispatch, so we only need to act once per process.
      */
     private bool $persisted = false;
 
@@ -80,15 +62,15 @@ class RouteCache
         }
     }
 
+    /**
+     * @internal
+     */
     public function isEnabled(): bool
     {
         return $this->path !== false;
     }
 
     /**
-     * Returns the cached tokens for $path, or null if not cached.
-     * Calling this also marks the path as touched so persist() retains it.
-     *
      * @return string[]|null
      */
     public function getCached(string $path): ?array
@@ -97,15 +79,13 @@ class RouteCache
             return null;
         }
 
+        // Touch on read so persist() retains the entry even when no new
+        // record() call confirms it this run.
         $this->touched[$path] = true;
         return $this->tokens[$path];
     }
 
     /**
-     * Records that $path was registered with the given tokens. Used both
-     * for newly-parsed routes (cold misses) and for re-asserting cached
-     * routes (so they're retained on persist).
-     *
      * @param string[] $tokens
      */
     public function record(string $path, array $tokens): void
@@ -118,10 +98,9 @@ class RouteCache
     }
 
     /**
-     * Writes the cache file if anything changed during this run.
-     * Idempotent: subsequent calls after a successful run are cheap no-ops.
-     * Silently no-ops if caching is disabled. Silently swallows write
-     * failures; if the write fails, the next call will retry.
+     * Best-effort write of the cache file. Idempotent across a process;
+     * silently swallows write failures so the application is unaffected by
+     * an unwritable cache.
      */
     public function persist(): void
     {
@@ -134,8 +113,8 @@ class RouteCache
             return;
         }
 
-        // Routes still in $tokens but not in $touched were removed from
-        // user code since the cache was last written; drop them.
+        // Drop entries that weren't touched this run — those routes were
+        // removed from user code since the cache was last written.
         $pruned = array_intersect_key($this->tokens, $this->touched);
         if (count($pruned) !== count($this->tokens)) {
             $this->tokens = $pruned;
@@ -164,15 +143,12 @@ class RouteCache
         }
     }
 
-    /**
-     * Loads the cache file if it exists. Silently no-ops on read or
-     * parse failure. @include returns false (with suppressed warning)
-     * when the file is missing or unreadable, so an explicit existence
-     * check would be redundant.
-     */
     private function load(): void
     {
         try {
+            // @include returns false on missing/unreadable files; that path is
+            // handled by the is_array check, so we skip an explicit existence
+            // pre-check (which would race against the include anyway).
             $loaded = @include $this->path;
             if (is_array($loaded)) {
                 $this->tokens = $loaded;

--- a/src/RouteCache.php
+++ b/src/RouteCache.php
@@ -63,6 +63,14 @@ class RouteCache
     private bool $dirty = false;
 
     /**
+     * Whether persist() has already done its work successfully this run.
+     * Used to short-circuit on the request hot path: persist() is called
+     * from Application::handle() on every request, but the cache shape
+     * cannot change during dispatch, so we only need to act once.
+     */
+    private bool $persisted = false;
+
+    /**
      * @param string|false $path Path to the cache file, or false to disable caching.
      */
     public function __construct(private string|false $path)
@@ -111,24 +119,31 @@ class RouteCache
 
     /**
      * Writes the cache file if anything changed during this run.
+     * Idempotent: subsequent calls after a successful run are cheap no-ops.
      * Silently no-ops if caching is disabled. Silently swallows write
-     * failures (e.g. unwritable destination).
+     * failures; if the write fails, the next call will retry.
      */
     public function persist(): void
     {
-        if ($this->path === false) {
+        if ($this->persisted) {
             return;
         }
 
-        // Detect entries that were in the cache but never touched this run.
-        // Those are routes that have been removed from user code; prune them.
-        $stale = array_diff_key($this->tokens, $this->touched);
-        if (! empty($stale)) {
-            $this->tokens = array_intersect_key($this->tokens, $this->touched);
+        if ($this->path === false) {
+            $this->persisted = true;
+            return;
+        }
+
+        // Routes still in $tokens but not in $touched were removed from
+        // user code since the cache was last written; drop them.
+        $pruned = array_intersect_key($this->tokens, $this->touched);
+        if (count($pruned) !== count($this->tokens)) {
+            $this->tokens = $pruned;
             $this->dirty = true;
         }
 
         if (! $this->dirty) {
+            $this->persisted = true;
             return;
         }
 
@@ -139,24 +154,24 @@ class RouteCache
             if (! is_dir($dir)) {
                 @mkdir($dir, 0755, true);
             }
-            @file_put_contents($this->path, $contents, LOCK_EX);
+            $bytes = @file_put_contents($this->path, $contents, LOCK_EX);
+            if ($bytes !== false) {
+                $this->dirty = false;
+                $this->persisted = true;
+            }
         } catch (Throwable) {
             // Caching is best-effort. Failures are silent by design.
         }
-
-        $this->dirty = false;
     }
 
     /**
      * Loads the cache file if it exists. Silently no-ops on read or
-     * parse failure.
+     * parse failure. @include returns false (with suppressed warning)
+     * when the file is missing or unreadable, so an explicit existence
+     * check would be redundant.
      */
     private function load(): void
     {
-        if (! is_string($this->path) || ! is_file($this->path) || ! is_readable($this->path)) {
-            return;
-        }
-
         try {
             $loaded = @include $this->path;
             if (is_array($loaded)) {

--- a/src/RouteCache.php
+++ b/src/RouteCache.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CCGLabs\Router;
+
+use Throwable;
+
+/**
+ * RouteCache persists parsed route token lists to a PHP file so that the
+ * cost of parsing route patterns can be skipped on subsequent requests.
+ *
+ * The cache stores only structural data (a path-string to token-list map),
+ * not handlers — handlers remain in user code and are wired up on every
+ * request as usual.
+ *
+ * The cache is implicit and defensive: failures to load or persist the
+ * cache file never throw. In the worst case the application runs without
+ * caching, parsing routes from scratch as if the cache were absent.
+ *
+ * Pass false to the constructor to disable caching entirely.
+ */
+class RouteCache
+{
+    /**
+     * Path-prefix used by defaultPath() under sys_get_temp_dir().
+     */
+    public const DEFAULT_PATH_PREFIX = 'ccglabs-router-';
+
+    /**
+     * Returns the default cache file path: a PHP file in the system
+     * temp directory whose name is derived from the current working
+     * directory so that different projects on the same host get
+     * different default cache files.
+     */
+    public static function defaultPath(): string
+    {
+        $cwd = getcwd() ?: __FILE__;
+        $hash = substr(md5($cwd), 0, 16);
+        return sys_get_temp_dir() . DIRECTORY_SEPARATOR . self::DEFAULT_PATH_PREFIX . $hash . '.php';
+    }
+
+    /**
+     * Path-string to token-list map. Loaded from the cache file at
+     * construction; mutated by record() during route registration;
+     * trimmed and rewritten by persist().
+     *
+     * @var array<string, string[]>
+     */
+    private array $tokens = [];
+
+    /**
+     * Set of path-strings recorded or hit during this run. Used by
+     * persist() to prune entries no longer in the route table.
+     *
+     * @var array<string, true>
+     */
+    private array $touched = [];
+
+    /**
+     * Whether persist() needs to write the cache file.
+     */
+    private bool $dirty = false;
+
+    /**
+     * @param string|false $path Path to the cache file, or false to disable caching.
+     */
+    public function __construct(private string|false $path)
+    {
+        if ($this->path !== false) {
+            $this->load();
+        }
+    }
+
+    public function isEnabled(): bool
+    {
+        return $this->path !== false;
+    }
+
+    /**
+     * Returns the cached tokens for $path, or null if not cached.
+     * Calling this also marks the path as touched so persist() retains it.
+     *
+     * @return string[]|null
+     */
+    public function getCached(string $path): ?array
+    {
+        if (! isset($this->tokens[$path])) {
+            return null;
+        }
+
+        $this->touched[$path] = true;
+        return $this->tokens[$path];
+    }
+
+    /**
+     * Records that $path was registered with the given tokens. Used both
+     * for newly-parsed routes (cold misses) and for re-asserting cached
+     * routes (so they're retained on persist).
+     *
+     * @param string[] $tokens
+     */
+    public function record(string $path, array $tokens): void
+    {
+        if (! isset($this->tokens[$path]) || $this->tokens[$path] !== $tokens) {
+            $this->tokens[$path] = $tokens;
+            $this->dirty = true;
+        }
+        $this->touched[$path] = true;
+    }
+
+    /**
+     * Writes the cache file if anything changed during this run.
+     * Silently no-ops if caching is disabled. Silently swallows write
+     * failures (e.g. unwritable destination).
+     */
+    public function persist(): void
+    {
+        if ($this->path === false) {
+            return;
+        }
+
+        // Detect entries that were in the cache but never touched this run.
+        // Those are routes that have been removed from user code; prune them.
+        $stale = array_diff_key($this->tokens, $this->touched);
+        if (! empty($stale)) {
+            $this->tokens = array_intersect_key($this->tokens, $this->touched);
+            $this->dirty = true;
+        }
+
+        if (! $this->dirty) {
+            return;
+        }
+
+        $contents = "<?php\n\nreturn " . var_export($this->tokens, true) . ";\n";
+
+        try {
+            $dir = dirname($this->path);
+            if (! is_dir($dir)) {
+                @mkdir($dir, 0755, true);
+            }
+            @file_put_contents($this->path, $contents, LOCK_EX);
+        } catch (Throwable) {
+            // Caching is best-effort. Failures are silent by design.
+        }
+
+        $this->dirty = false;
+    }
+
+    /**
+     * Loads the cache file if it exists. Silently no-ops on read or
+     * parse failure.
+     */
+    private function load(): void
+    {
+        if (! is_string($this->path) || ! is_file($this->path) || ! is_readable($this->path)) {
+            return;
+        }
+
+        try {
+            $loaded = @include $this->path;
+            if (is_array($loaded)) {
+                $this->tokens = $loaded;
+            }
+        } catch (Throwable) {
+            // Corrupt cache file: behave as if it didn't exist.
+        }
+    }
+}

--- a/src/Routes/TokenizedRoute.php
+++ b/src/Routes/TokenizedRoute.php
@@ -58,6 +58,22 @@ class TokenizedRoute implements IRenderableRoute
     }
 
     /**
+     * Returns the tokens that make up this route.
+     *
+     * Primarily intended for cache persistence: callers that have a route
+     * object and want to round-trip its parsed structure to disk can read
+     * the token list here and reconstruct the route via the constructor
+     * (which skips fromPath()'s validation, since the tokens were already
+     * validated when first parsed).
+     *
+     * @return string[]
+     */
+    public function getTokens(): array
+    {
+        return $this->tokens;
+    }
+
+    /**
      * Creates a TokenizedRoute from a string by splitting it on the path
      * separator ("/").
      *

--- a/tests/CCGLabs/Router/ApplicationTest.php
+++ b/tests/CCGLabs/Router/ApplicationTest.php
@@ -12,16 +12,49 @@ use CCGLabs\Router\HandlerLocators\DefaultHandlerLocator;
 use CCGLabs\Router\HandlerLocators\IHandlerLocator;
 use CCGLabs\Router\HTTP\Verb;
 use CCGLabs\Router\IRoute;
+use CCGLabs\Router\RouteCache;
 use CCGLabs\Router\RouteMatch;
 use CCGLabs\Router\Routes\TokenizedRoute;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\UriInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
 class ApplicationTest extends TestCase
 {
+    private string $cacheFile = '';
+
+    protected function setUp(): void
+    {
+        $this->cacheFile = (tempnam(sys_get_temp_dir(), 'ccglabs-router-app-test-') ?: '');
+        @unlink($this->cacheFile);
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->cacheFile);
+    }
+
+    /**
+     * Builds a stub request that locate() will accept, plus a mock locator
+     * that returns a RouteMatch with a no-op handler. Used by tests that
+     * need to call handle() to trigger cache persistence.
+     */
+    private function makeHandledRequest(): ServerRequestInterface
+    {
+        $uri = $this->createStub(UriInterface::class);
+        $uri->method('getPath')->willReturn('/__ccglabs_test_cache_trigger__');
+
+        $request = $this->createStub(ServerRequestInterface::class);
+        $request->method('getMethod')->willReturn('GET');
+        $request->method('getUri')->willReturn($uri);
+        $request->method('withAttribute')->willReturnSelf();
+
+        return $request;
+    }
+
     public function testConstuctorWithNoArgumentsUsesDefaultHandlerLocator(): void
     {
         $application = new Application();
@@ -465,14 +498,120 @@ class ApplicationTest extends TestCase
 
     public function testNameCanBeReusedForLastRegistration(): void
     {
-        // If a user registers two routes with the same name, the most
-        // recent one wins. This matches user expectation: re-registering
-        // a name overrides.
         $app = new Application();
         $app->get('/old/{id}', fn () => null, name: 'show');
         $app->get('/new/{id}', fn () => null, name: 'show');
 
         $this->assertSame('/new/42', $app->urlFor('show', ['id' => '42']));
+    }
+
+    // Route caching
+
+    public function testCacheFileIsCreatedAfterHandlingFirstRequest(): void
+    {
+        $app = new Application(cacheFile: $this->cacheFile);
+        $app->get('/users/{id}', fn () => null);
+        $app->get('/posts/{year}/{slug}', fn () => null);
+
+        // Trigger persist via handle(). The locator will throw because no
+        // route matches '/__ccglabs_test_cache_trigger__'; that's fine —
+        // persist runs before locate.
+        try {
+            $app->handle($this->makeHandledRequest());
+        } catch (\Throwable) {
+            // Expected — no route matches the trigger path.
+        }
+
+        $this->assertFileExists($this->cacheFile);
+        $loaded = include $this->cacheFile;
+        $this->assertArrayHasKey('/users/{id}', $loaded);
+        $this->assertArrayHasKey('/posts/{year}/{slug}', $loaded);
+        $this->assertSame(['', 'users', '{id}'], $loaded['/users/{id}']);
+    }
+
+    public function testCacheFalseDisablesFileCreation(): void
+    {
+        $app = new Application(cacheFile: false);
+        $app->get('/users/{id}', fn () => null);
+
+        try {
+            $app->handle($this->makeHandledRequest());
+        } catch (\Throwable) {
+        }
+
+        $this->assertFileDoesNotExist($this->cacheFile);
+    }
+
+    public function testCacheFailureIsNonFatal(): void
+    {
+        $app = new Application(cacheFile: '/proc/self/nonexistent/cache.php');
+        $app->get('/users/{id}', fn () => null);
+
+        try {
+            $app->handle($this->makeHandledRequest());
+        } catch (\CCGLabs\Router\Exceptions\RouteHandlerNotFoundException) {
+        }
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    public function testIRouteObjectsAreNotCached(): void
+    {
+        $route = $this->createStub(IRoute::class);
+        $route->method('matches')->willReturn(null);
+
+        $app = new Application(cacheFile: $this->cacheFile);
+        $app->addRoute(Verb::GET, $route, fn () => null);
+
+        try {
+            $app->handle($this->makeHandledRequest());
+        } catch (\Throwable) {
+        }
+
+        $loaded = file_exists($this->cacheFile) ? include $this->cacheFile : [];
+        $this->assertSame([], $loaded);
+    }
+
+    public function testApplicationConsumesPrePopulatedCache(): void
+    {
+        $cache = new RouteCache($this->cacheFile);
+        $cache->record('/users/{id}', ['', 'users', '{id}']);
+        $cache->persist();
+        $contentBefore = file_get_contents($this->cacheFile);
+
+        $app = new Application(cacheFile: $this->cacheFile);
+        $app->get('/users/{id}', fn () => null);
+        try {
+            $app->handle($this->makeHandledRequest());
+        } catch (\Throwable) {
+        }
+
+        $this->assertSame($contentBefore, file_get_contents($this->cacheFile));
+    }
+
+    public function testRemovedRoutesArePrunedFromCacheOnReregistration(): void
+    {
+        $app1 = new Application(cacheFile: $this->cacheFile);
+        $app1->get('/a', fn () => null);
+        $app1->get('/b', fn () => null);
+        try {
+            $app1->handle($this->makeHandledRequest());
+        } catch (\Throwable) {
+        }
+
+        $this->assertArrayHasKey('/a', include $this->cacheFile);
+        $this->assertArrayHasKey('/b', include $this->cacheFile);
+
+        $app2 = new Application(cacheFile: $this->cacheFile);
+        $app2->get('/a', fn () => null);
+        try {
+            $app2->handle($this->makeHandledRequest());
+        } catch (\Throwable) {
+        }
+
+        $loaded = include $this->cacheFile;
+        $this->assertArrayHasKey('/a', $loaded);
+        $this->assertArrayNotHasKey('/b', $loaded);
     }
 
     public function testMiddlewareCanModifyRequest(): void

--- a/tests/CCGLabs/Router/RouteCacheTest.php
+++ b/tests/CCGLabs/Router/RouteCacheTest.php
@@ -95,6 +95,27 @@ class RouteCacheTest extends TestCase
         $this->assertSame(['', 'new'], $thirdLoad->getCached('/new'));
     }
 
+    public function testRepeatPersistIsAOneShotNoop(): void
+    {
+        // First persist writes the file.
+        $cache = new RouteCache($this->tempFile);
+        $cache->record('/users/{id}', ['', 'users', '{id}']);
+        $cache->persist();
+
+        $mtimeAfterFirst = filemtime($this->tempFile);
+        clearstatcache(true, $this->tempFile);
+
+        // Wait long enough that a second write would update mtime.
+        usleep(10_000);
+
+        // Second persist must not re-write — the cache shape hasn't
+        // changed and persist() is on the request hot path.
+        $cache->persist();
+
+        clearstatcache(true, $this->tempFile);
+        $this->assertSame($mtimeAfterFirst, filemtime($this->tempFile));
+    }
+
     public function testPersistIsNoopWhenDisabled(): void
     {
         $cache = new RouteCache(false);

--- a/tests/CCGLabs/Router/RouteCacheTest.php
+++ b/tests/CCGLabs/Router/RouteCacheTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\CCGLabs\Router;
+
+use CCGLabs\Router\RouteCache;
+use PHPUnit\Framework\TestCase;
+
+class RouteCacheTest extends TestCase
+{
+    private string $tempFile;
+
+    protected function setUp(): void
+    {
+        $this->tempFile = tempnam(sys_get_temp_dir(), 'ccglabs-router-test-') ?: '';
+        // tempnam creates the file; we want a fresh path each test that may or may not exist
+        @unlink($this->tempFile);
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->tempFile);
+    }
+
+    public function testIsEnabledReturnsTrueWhenGivenAPath(): void
+    {
+        $cache = new RouteCache($this->tempFile);
+        $this->assertTrue($cache->isEnabled());
+    }
+
+    public function testIsEnabledReturnsFalseWhenGivenFalse(): void
+    {
+        $cache = new RouteCache(false);
+        $this->assertFalse($cache->isEnabled());
+    }
+
+    public function testGetCachedReturnsNullForUnknownPath(): void
+    {
+        $cache = new RouteCache($this->tempFile);
+        $this->assertNull($cache->getCached('/users/{id}'));
+    }
+
+    public function testRecordThenGetCachedReturnsTokens(): void
+    {
+        $cache = new RouteCache($this->tempFile);
+        $cache->record('/users/{id}', ['', 'users', '{id}']);
+
+        $this->assertSame(['', 'users', '{id}'], $cache->getCached('/users/{id}'));
+    }
+
+    public function testPersistWritesPhpFileReturningRecordedTokens(): void
+    {
+        $cache = new RouteCache($this->tempFile);
+        $cache->record('/users/{id}', ['', 'users', '{id}']);
+        $cache->record('/posts/{year}', ['', 'posts', '{year}']);
+        $cache->persist();
+
+        $this->assertFileExists($this->tempFile);
+        $loaded = include $this->tempFile;
+        $this->assertSame([
+            '/users/{id}' => ['', 'users', '{id}'],
+            '/posts/{year}' => ['', 'posts', '{year}'],
+        ], $loaded);
+    }
+
+    public function testNewCacheLoadsExistingFile(): void
+    {
+        $cache = new RouteCache($this->tempFile);
+        $cache->record('/users/{id}', ['', 'users', '{id}']);
+        $cache->persist();
+
+        $reloaded = new RouteCache($this->tempFile);
+        $this->assertSame(['', 'users', '{id}'], $reloaded->getCached('/users/{id}'));
+    }
+
+    public function testPersistPrunesEntriesNotTouchedThisRun(): void
+    {
+        // First run: register two routes.
+        $cache = new RouteCache($this->tempFile);
+        $cache->record('/old', ['', 'old']);
+        $cache->record('/keep/{id}', ['', 'keep', '{id}']);
+        $cache->persist();
+
+        // Second run: load cache, only "touch" /keep, register a new /new.
+        $reloaded = new RouteCache($this->tempFile);
+        $this->assertSame(['', 'keep', '{id}'], $reloaded->getCached('/keep/{id}'));  // touches
+        $reloaded->record('/new', ['', 'new']);
+        $reloaded->persist();
+
+        // /old should be gone; /keep and /new should remain.
+        $thirdLoad = new RouteCache($this->tempFile);
+        $this->assertNull($thirdLoad->getCached('/old'));
+        $this->assertSame(['', 'keep', '{id}'], $thirdLoad->getCached('/keep/{id}'));
+        $this->assertSame(['', 'new'], $thirdLoad->getCached('/new'));
+    }
+
+    public function testPersistIsNoopWhenDisabled(): void
+    {
+        $cache = new RouteCache(false);
+        $cache->record('/users/{id}', ['', 'users', '{id}']);
+        $cache->persist();
+
+        // Nothing to assert beyond "no exception thrown" — this is the contract.
+        $this->expectNotToPerformAssertions();
+    }
+
+    public function testPersistIsDefensiveAgainstUnwritablePath(): void
+    {
+        // /proc/self is read-only on Linux; trying to write a file under
+        // a non-existent subdirectory there will fail. RouteCache must
+        // swallow the error rather than throwing.
+        $cache = new RouteCache('/proc/self/nonexistent-dir/cache.php');
+        $cache->record('/users/{id}', ['', 'users', '{id}']);
+        $cache->persist();
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    public function testLoadIsDefensiveAgainstCorruptCacheFile(): void
+    {
+        file_put_contents($this->tempFile, '<?php this is not valid php at all !!!');
+
+        // Should not throw, just behave as if cache is empty.
+        $cache = new RouteCache($this->tempFile);
+        $this->assertNull($cache->getCached('/users/{id}'));
+    }
+
+    public function testLoadIsDefensiveAgainstNonArrayContent(): void
+    {
+        file_put_contents($this->tempFile, '<?php return "not an array";');
+
+        $cache = new RouteCache($this->tempFile);
+        $this->assertNull($cache->getCached('/users/{id}'));
+    }
+
+    public function testDefaultPathIsUnderTempDir(): void
+    {
+        $path = RouteCache::defaultPath();
+        $this->assertStringStartsWith(sys_get_temp_dir(), $path);
+        $this->assertStringEndsWith('.php', $path);
+    }
+
+    public function testDefaultPathIsStableForSameWorkingDirectory(): void
+    {
+        $a = RouteCache::defaultPath();
+        $b = RouteCache::defaultPath();
+        $this->assertSame($a, $b);
+    }
+}

--- a/tests/CCGLabs/Router/Routes/TokenizedRouteTest.php
+++ b/tests/CCGLabs/Router/Routes/TokenizedRouteTest.php
@@ -441,4 +441,19 @@ class TokenizedRouteTest extends TestCase
         $route = TokenizedRoute::fromPath('/');
         $this->assertSame('/', $route->render());
     }
+
+    public function testGetTokensReturnsConstructorTokens(): void
+    {
+        $tokens = ['users', '{id}', 'profile'];
+        $route = new TokenizedRoute($tokens);
+
+        $this->assertSame($tokens, $route->getTokens());
+    }
+
+    public function testGetTokensReturnsParsedTokensFromFromPath(): void
+    {
+        $route = TokenizedRoute::fromPath('/users/{id}');
+
+        $this->assertSame(['', 'users', '{id}'], $route->getTokens());
+    }
 }


### PR DESCRIPTION
## Summary

Caches parsed route patterns to a PHP file so route parsing cost is paid once, not on every request. Caching is on by default and silently degrades to no-cache if the cache file can't be read or written.

```php
// Default — caching enabled at sys_get_temp_dir() + cwd-derived path
$app = new Application();

// Explicit cache file path
$app = new Application(cacheFile: __DIR__ . '/cache/routes.php');

// Disable caching
$app = new Application(cacheFile: false);
```

## What's actually cached

Only the parsed `TokenizedRoute` token arrays — handlers (often closures, not `var_export`-able) stay in user code and run every request. The win is skipping `TokenizedRoute::fromPath()` validation on every request after the first.

## Design decisions (locked under v3.0+ stability rule)

- **Implicit, opt-out:** caching is on by default with a default path under `sys_get_temp_dir()` derived from `getcwd()` (so multiple projects on the same host don't collide). Pass `cacheFile: false` to disable.
- **Defensive:** read failures (corrupt cache, missing file) and write failures (unwritable path, full disk) are silently swallowed. The app keeps working without caching.
- **Pattern-only:** because PHP closures can't be `var_export`'d, the cache contains only the parsed token lists. Handlers are always re-attached at registration time on every request.
- **Cache invalidation:** path-keyed map. Missing-from-cache → parse and record. In-cache-but-not-registered → pruned on persist. No mtime checks, no manual invalidation.
- **New API surface (locked):** `RouteCache` class, `Application` constructor's second optional `string|false|null \$cacheFile = null` parameter, `TokenizedRoute::getTokens()` accessor.

## Test plan

- [x] All 102 tests pass (up from 81: +13 RouteCache, +6 Application integration, +2 getTokens)
- [x] CS check clean (only the pre-existing long-line on `TokenizedRoute.php:33`, unrelated)
- [ ] Reviewer sanity-check the default-path collision strategy (cwd hash under sys_get_temp_dir)
- [ ] Reviewer review the new public surface (`RouteCache` class shape, the constructor's union type)

## Notes

- Built on top of `cleanup` because that branch carries v3.0 + v3.0.1. Those should be reviewed/merged as their own PR.
- Versioned as 3.2.0; 3.1.0 is reserved for the open named-routes PR (#21). If named-routes merges first, this is 3.2.0; if this merges first, the maintainer can renumber on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)