### PR TITLE
style: wrap long ERROR_INVALID_PARAMETER_NAME constant

### DIFF
--- a/src/Routes/TokenizedRoute.php
+++ b/src/Routes/TokenizedRoute.php
@@ -28,7 +28,8 @@ class TokenizedRoute implements IParameterizedRoute
     public const ERROR_INVALID_TOKEN = '"%s" is an invalid url token';
     public const ERROR_INVALID_PATH = 'Invalid route path: %s';
     public const ERROR_EMPTY_PARAMETER = 'Empty parameter names are not allowed';
-    public const ERROR_INVALID_PARAMETER_NAME = 'Invalid parameter name "%s": must contain only letters, numbers, and underscores, and start with a letter or underscore';
+    public const ERROR_INVALID_PARAMETER_NAME = 'Invalid parameter name "%s": must contain only '
+        . 'letters, numbers, and underscores, and start with a letter or underscore';
     public const ERROR_DUPLICATE_PARAMETER = 'Duplicate parameter name "%s" in route path';
     public const ERROR_PATH_TOO_LONG = 'Route path exceeds maximum length of %d characters';
     public const ERROR_TOO_MANY_SEGMENTS = 'Route path exceeds maximum of %d segments';


### PR DESCRIPTION
## Summary
- Splits the 170-character `ERROR_INVALID_PARAMETER_NAME` constant in `src/Routes/TokenizedRoute.php` across two concatenated lines so the file no longer trips the PSR-12 120-char line-length warning.
- The runtime constant value is unchanged (PHP evaluates the string concatenation at parse time), so all existing tests and exception-message assertions continue to pass.

## Why
The CI `Code Style` job runs `composer cs:check -- --report=checkstyle | cs2pr`, which exits non-zero on phpcs warnings. The long line on `main` causes that job to fail on every PR, including the currently-open Dependabot bumps:
- #19 (phpunit/phpunit 12.5.3 → 12.5.8)
- #20 (codecov/codecov-action v5 → v6)

Both have all substantive checks (Tests, Static Analysis, Security) passing — only the pre-existing Code Style failure is blocking them. After this PR lands, rebasing those PRs (or commenting `@dependabot rebase`) should turn them green.

## Test plan
- [x] `composer cs:check` is clean (no errors, no warnings)
- [x] `XDEBUG_MODE=coverage vendor/bin/phpunit --no-coverage` — 80/80 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)