### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# All paths owned by CCG Labs core developers
+* @CCG-Labs/ccg-labs-developers


### PR DESCRIPTION
Adds `.github/CODEOWNERS` mapping all paths to `@CCG-Labs/ccg-labs-developers`.